### PR TITLE
Pin to style version

### DIFF
--- a/ViewAnnotationDemo/ViewController.swift
+++ b/ViewAnnotationDemo/ViewController.swift
@@ -15,7 +15,7 @@ class ViewController: UIViewController, MGLMapViewDelegate {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        map = MGLMapView(frame: view.bounds, styleURL: MGLStyle.darkStyleURLWithVersion(MGLStyleDefaultVersion))
+        map = MGLMapView(frame: view.bounds, styleURL: MGLStyle.darkStyleURLWithVersion(9))
         if let map = map {
             map.setCenterCoordinate(centerCoordinate, zoomLevel: 12, animated: false)
             map.autoresizingMask = [.FlexibleWidth, .FlexibleHeight]


### PR DESCRIPTION
Although this demo doesn’t make use of any details in the Dark style that would break between style releases, we probably shouldn’t be encouraging developers to use this constant for any purpose other than knowing what MGLMapView, MGLTilePyramidOfflineRegion, or MGLStyle defaults to. See https://github.com/mapbox/mapbox-gl-native/pull/4759#discussion_r60455953 for further discussion about this constant.

/cc @incanus @friedbunny
